### PR TITLE
[#11] feat: 휴대폰 SMS 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2' // H2
     runtimeOnly 'com.mysql:mysql-connector-j'   // MySQL
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'    // Redis
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.0'  // MyBatis
 
     implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'   // bcrypt 암호화

--- a/src/main/java/com/ghm/giftcardfleamarket/common/config/RedisConfig.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.ghm.giftcardfleamarket.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisHost, redisPort);
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate() {
+		StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+		stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+		return stringRedisTemplate;
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/common/config/WebConfig.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.ghm.giftcardfleamarket.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/handler/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.ghm.giftcardfleamarket.user.exception.DuplicatedEmailException;
 import com.ghm.giftcardfleamarket.user.exception.DuplicatedPhoneException;
 import com.ghm.giftcardfleamarket.user.exception.DuplicatedUserIdException;
+import com.ghm.giftcardfleamarket.user.exception.verification.SmsSendFailedException;
+import com.ghm.giftcardfleamarket.user.exception.verification.VerificationCodeMisMatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -19,5 +21,15 @@ public class GlobalExceptionHandler {
 	})
 	public ResponseEntity<String> handleDuplicatedExceptions(RuntimeException e) {
 		return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
+	}
+
+	@ExceptionHandler(SmsSendFailedException.class)
+	public ResponseEntity<String> handleSmsSendFailedException(SmsSendFailedException e) {
+		return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(VerificationCodeMisMatchException.class)
+	public ResponseEntity<String> handleVerificationCodeMisMatchException(VerificationCodeMisMatchException e) {
+		return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/handler/GlobalExceptionHandler.java
@@ -25,27 +25,8 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(SmsSendFailedException.class)
 	public ResponseEntity<String> handleSmsSendFailedException(SmsSendFailedException e) {
-		HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-
-		switch (e.getErrorCode()) {
-			case "400":
-				httpStatus = HttpStatus.BAD_REQUEST;
-				break;
-			case "401":
-				httpStatus = HttpStatus.UNAUTHORIZED;
-				break;
-			case "403":
-				httpStatus = HttpStatus.FORBIDDEN;
-				break;
-			case "404":
-				httpStatus = HttpStatus.NOT_FOUND;
-				break;
-			case "429":
-				httpStatus = HttpStatus.TOO_MANY_REQUESTS;
-				break;
-		}
-
-		return new ResponseEntity<>(httpStatus);
+		int statusCode = Integer.parseInt(e.getErrorCode());
+		return new ResponseEntity<>(HttpStatus.valueOf(statusCode));
 	}
 
 	@ExceptionHandler(VerificationCodeMisMatchException.class)

--- a/src/main/java/com/ghm/giftcardfleamarket/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/handler/GlobalExceptionHandler.java
@@ -25,7 +25,27 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(SmsSendFailedException.class)
 	public ResponseEntity<String> handleSmsSendFailedException(SmsSendFailedException e) {
-		return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+
+		switch (e.getErrorCode()) {
+			case "400":
+				httpStatus = HttpStatus.BAD_REQUEST;
+				break;
+			case "401":
+				httpStatus = HttpStatus.UNAUTHORIZED;
+				break;
+			case "403":
+				httpStatus = HttpStatus.FORBIDDEN;
+				break;
+			case "404":
+				httpStatus = HttpStatus.NOT_FOUND;
+				break;
+			case "429":
+				httpStatus = HttpStatus.TOO_MANY_REQUESTS;
+				break;
+		}
+
+		return new ResponseEntity<>(httpStatus);
 	}
 
 	@ExceptionHandler(VerificationCodeMisMatchException.class)

--- a/src/main/java/com/ghm/giftcardfleamarket/common/utils/SmsVerificationUtil.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/utils/SmsVerificationUtil.java
@@ -1,0 +1,93 @@
+package com.ghm.giftcardfleamarket.common.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import com.ghm.giftcardfleamarket.user.dto.request.MessageRequest;
+import com.ghm.giftcardfleamarket.user.dto.request.SmsApiRequest;
+
+public class SmsVerificationUtil {
+
+	private static final String ACCESS_KEY = "iJPkzp82Zq6cU4XgmuQv";
+	private static final String SECRET_KEY = "Rtfhw7caZMJyOksfnRcVTH897dhi7ndAnbx62Oei";
+	private static final String SERVICE_ID = "ncp:sms:kr:306692833450:flea_market";
+	private static final String SENDER = "01024008614";
+
+	private SmsVerificationUtil() {
+	}
+
+	public static String makeVerificationCode() {
+		return String.valueOf(new Random().nextInt(900000) + 100000);
+	}
+
+	public static HttpHeaders makeSmsApiRequestHeaders() {
+		String timestamp = Long.toString(System.currentTimeMillis());
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.add("x-ncp-apigw-timestamp", timestamp);
+		headers.add("x-ncp-iam-access-key", ACCESS_KEY);
+		headers.add("x-ncp-apigw-signature-v2", makeSignature(timestamp));
+		return headers;
+	}
+
+	public static SmsApiRequest makeSmsApiRequestBody(String phone, String verificationCode) {
+		List<MessageRequest> messages = new ArrayList<>();
+		messages.add(MessageRequest.builder()
+			.to(phone)
+			.content(String.format("[기프티콘 플리마켓] 인증 번호 [%s]를 입력해주세요.", verificationCode))
+			.build());
+
+		return SmsApiRequest.builder()
+			.type("SMS")
+			.contentType("COMM")
+			.countryCode("82")
+			.from(SENDER)
+			.content("기본 메시지")
+			.messages(messages)
+			.build();
+	}
+
+	public static String makeSignature(String timestamp) {
+		String space = " ";
+		String newLine = "\n";
+		String method = "POST";
+		String url = "/sms/v2/services/" + SERVICE_ID + "/messages";
+
+		String message = new StringBuilder()
+			.append(method)
+			.append(space)
+			.append(url)
+			.append(newLine)
+			.append(timestamp)
+			.append(newLine)
+			.append(ACCESS_KEY)
+			.toString();
+
+		SecretKeySpec signingKey = new SecretKeySpec(SECRET_KEY.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+
+		Mac mac = null;
+		try {
+			mac = Mac.getInstance("HmacSHA256");
+			mac.init(signingKey);
+		} catch (NoSuchAlgorithmException | InvalidKeyException e) {
+			throw new RuntimeException(e);
+		}
+
+		byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+		String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+		return encodeBase64String;
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/controller/UserController.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/controller/UserController.java
@@ -10,8 +10,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ghm.giftcardfleamarket.user.dto.request.SignUpRequest;
+import com.ghm.giftcardfleamarket.user.dto.request.SmsVerificationRequest;
 import com.ghm.giftcardfleamarket.user.service.UserService;
+import com.ghm.giftcardfleamarket.user.service.verification.SmsVerificationService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final UserService userService;
+	private final SmsVerificationService smsVerificationService;
 
 	@PostMapping
 	public ResponseEntity<String> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
@@ -32,5 +36,19 @@ public class UserController {
 	public ResponseEntity<Boolean> checkUserIdDuplication(@PathVariable String userId) {
 		userService.checkUserIdDuplication(userId);
 		return new ResponseEntity<>(Boolean.FALSE, HttpStatus.OK);
+	}
+
+	@PostMapping("/sms-verification")
+	public ResponseEntity<String> sendSms(@RequestBody SmsVerificationRequest smsRequest) throws
+		JsonProcessingException {
+
+		smsVerificationService.sendSms(smsRequest.getPhone());
+		return new ResponseEntity<>(HttpStatus.ACCEPTED);
+	}
+
+	@PostMapping("/sms-verification/verify")
+	public ResponseEntity<String> verify(@RequestBody @Validated SmsVerificationRequest smsRequest) {
+		smsVerificationService.verifyVerificationCode(smsRequest);
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/user/dao/SmsVerificationDao.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/dao/SmsVerificationDao.java
@@ -1,0 +1,31 @@
+package com.ghm.giftcardfleamarket.user.dao;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SmsVerificationDao {
+
+	private final StringRedisTemplate redisTemplate;
+
+	@Value("${spring.data.redis.timeout}")
+	private long TIME_OUT;
+
+	public void saveVerificationCode(String phone, String verificationCode) {
+		redisTemplate.opsForValue().set(phone, verificationCode, Duration.ofMillis(TIME_OUT));
+	}
+
+	public String getVerificationCode(String phone) {
+		return redisTemplate.opsForValue().get(phone);
+	}
+
+	public void deleteVerificationCode(String phone) {
+		redisTemplate.delete(phone);
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/dao/SmsVerificationDao.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/dao/SmsVerificationDao.java
@@ -15,10 +15,10 @@ public class SmsVerificationDao {
 	private final StringRedisTemplate redisTemplate;
 
 	@Value("${spring.data.redis.timeout}")
-	private long TIME_OUT;
+	private long TIMEOUT_IN_MILLIS;
 
 	public void saveVerificationCode(String phone, String verificationCode) {
-		redisTemplate.opsForValue().set(phone, verificationCode, Duration.ofMillis(TIME_OUT));
+		redisTemplate.opsForValue().set(phone, verificationCode, Duration.ofMillis(TIMEOUT_IN_MILLIS));
 	}
 
 	public String getVerificationCode(String phone) {

--- a/src/main/java/com/ghm/giftcardfleamarket/user/dto/request/MessageRequest.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/dto/request/MessageRequest.java
@@ -1,0 +1,11 @@
+package com.ghm.giftcardfleamarket.user.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MessageRequest {
+	private final String to;
+	private final String content;
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/dto/request/SmsApiRequest.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/dto/request/SmsApiRequest.java
@@ -1,0 +1,17 @@
+package com.ghm.giftcardfleamarket.user.dto.request;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SmsApiRequest {
+	private final String type;
+	private final String contentType;
+	private final String countryCode;
+	private final String from;
+	private final String content;
+	private final List<MessageRequest> messages;
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/dto/request/SmsVerificationRequest.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/dto/request/SmsVerificationRequest.java
@@ -1,0 +1,18 @@
+package com.ghm.giftcardfleamarket.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SmsVerificationRequest {
+
+	@NotBlank(message = "휴대폰 번호 입력은 필수입니다.")
+	@Pattern(regexp = "^(010|011)[0-9]{8}$", message = "휴대폰 번호 형식에 맞게 입력해 주세요.")
+	private String phone;
+
+	@NotBlank(message = "인증 번호 입력은 필수입니다.")
+	@Size(min = 6, max = 6, message = "인증 번호는 {mix}자리 입니다.")
+	private String verificationCode;
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/dto/response/SmsApiResponse.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/dto/response/SmsApiResponse.java
@@ -1,0 +1,11 @@
+package com.ghm.giftcardfleamarket.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class SmsApiResponse {
+	private String requestId;
+	private String requestTime;
+	private String statusCode;
+	private String statusName;
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/exception/verification/SmsSendFailedException.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/exception/verification/SmsSendFailedException.java
@@ -1,0 +1,8 @@
+package com.ghm.giftcardfleamarket.user.exception.verification;
+
+public class SmsSendFailedException extends RuntimeException {
+
+	public SmsSendFailedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/exception/verification/SmsSendFailedException.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/exception/verification/SmsSendFailedException.java
@@ -2,7 +2,13 @@ package com.ghm.giftcardfleamarket.user.exception.verification;
 
 public class SmsSendFailedException extends RuntimeException {
 
-	public SmsSendFailedException(String message) {
-		super(message);
+	private String errorCode;
+
+	public SmsSendFailedException(String errorCode) {
+		this.errorCode = errorCode;
+	}
+
+	public String getErrorCode() {
+		return errorCode;
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/user/exception/verification/VerificationCodeMisMatchException.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/exception/verification/VerificationCodeMisMatchException.java
@@ -1,0 +1,8 @@
+package com.ghm.giftcardfleamarket.user.exception.verification;
+
+public class VerificationCodeMisMatchException extends RuntimeException {
+	
+	public VerificationCodeMisMatchException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
@@ -33,9 +33,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SmsVerificationService {
 
-	private final RestTemplate restTemplate;
-	private final SmsVerificationDao smsCertificationDao;
-
 	private static final String ACCESS_KEY = "iJPkzp82Zq6cU4XgmuQv";
 	private static final String SECRET_KEY = "Rtfhw7caZMJyOksfnRcVTH897dhi7ndAnbx62Oei";
 	private static final String SERVICE_ID = "ncp:sms:kr:306692833450:flea_market";
@@ -43,7 +40,9 @@ public class SmsVerificationService {
 	private static final String REQUEST_URL =
 		"https://sens.apigw.ntruss.com/sms/v2/services/" + SERVICE_ID + "/messages";
 
-	// 네이버 SMS API를 이용해 인증번호 발송하고 Redis에 저장
+	private final RestTemplate restTemplate;
+	private final SmsVerificationDao smsCertificationDao;
+
 	public void sendSms(String phone) throws JsonProcessingException {
 		HttpHeaders headers = makeSmsApiRequestHeaders();
 		String verificationCode = makeVerificationCode();
@@ -59,7 +58,6 @@ public class SmsVerificationService {
 		smsCertificationDao.saveVerificationCode(phone, verificationCode);
 	}
 
-	// 네이버 SMS API로 보낼 요청 헤더 생성
 	private HttpHeaders makeSmsApiRequestHeaders() {
 		String timestamp = Long.toString(System.currentTimeMillis());
 
@@ -75,7 +73,6 @@ public class SmsVerificationService {
 		return String.valueOf(new Random().nextInt(900000) + 100000);
 	}
 
-	// 네이버 SMS API로 보낼 요청 바디 생성
 	private SmsApiRequest makeSmsApiRequestBody(String phone, String verificationCode) {
 		List<MessageRequest> messages = new ArrayList<>();
 		messages.add(MessageRequest.builder()
@@ -93,7 +90,6 @@ public class SmsVerificationService {
 			.build();
 	}
 
-	// 인증 번호 확인
 	public void verifyVerificationCode(SmsVerificationRequest smsRequest) {
 		String findCode = smsCertificationDao.getVerificationCode(smsRequest.getPhone());
 		if (!smsRequest.getVerificationCode().equals(findCode)) {

--- a/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
@@ -1,0 +1,136 @@
+package com.ghm.giftcardfleamarket.user.service.verification;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ghm.giftcardfleamarket.user.dao.SmsVerificationDao;
+import com.ghm.giftcardfleamarket.user.dto.request.MessageRequest;
+import com.ghm.giftcardfleamarket.user.dto.request.SmsApiRequest;
+import com.ghm.giftcardfleamarket.user.dto.request.SmsVerificationRequest;
+import com.ghm.giftcardfleamarket.user.dto.response.SmsApiResponse;
+import com.ghm.giftcardfleamarket.user.exception.verification.SmsSendFailedException;
+import com.ghm.giftcardfleamarket.user.exception.verification.VerificationCodeMisMatchException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SmsVerificationService {
+
+	private final RestTemplate restTemplate;
+	private final SmsVerificationDao smsCertificationDao;
+
+	private static final String ACCESS_KEY = "iJPkzp82Zq6cU4XgmuQv";
+	private static final String SECRET_KEY = "Rtfhw7caZMJyOksfnRcVTH897dhi7ndAnbx62Oei";
+	private static final String SERVICE_ID = "ncp:sms:kr:306692833450:flea_market";
+	private static final String SENDER = "01024008614";
+	private static final String REQUEST_URL =
+		"https://sens.apigw.ntruss.com/sms/v2/services/" + SERVICE_ID + "/messages";
+
+	// 네이버 SMS API를 이용해 인증번호 발송하고 Redis에 저장
+	public void sendSms(String phone) throws JsonProcessingException {
+		HttpHeaders headers = makeSmsApiRequestHeaders();
+		String verificationCode = makeVerificationCode();
+		SmsApiRequest body = makeSmsApiRequestBody(phone, verificationCode);
+
+		String jsonStrBody = new ObjectMapper().writeValueAsString(body);
+		HttpEntity<String> httpRequest = new HttpEntity<>(jsonStrBody, headers);
+
+		SmsApiResponse smsApiResponse = restTemplate.postForObject(REQUEST_URL, httpRequest, SmsApiResponse.class);
+		if (smsApiResponse.getStatusName().equals("fail")) {
+			throw new SmsSendFailedException("SMS 전송에 실패하였습니다.");
+		}
+		smsCertificationDao.saveVerificationCode(phone, verificationCode);
+	}
+
+	// 네이버 SMS API로 보낼 요청 헤더 생성
+	private HttpHeaders makeSmsApiRequestHeaders() {
+		String timestamp = Long.toString(System.currentTimeMillis());
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.add("x-ncp-apigw-timestamp", timestamp);
+		headers.add("x-ncp-iam-access-key", ACCESS_KEY);
+		headers.add("x-ncp-apigw-signature-v2", makeSignature(timestamp));
+		return headers;
+	}
+
+	private static String makeVerificationCode() {
+		return String.valueOf(new Random().nextInt(900000) + 100000);
+	}
+
+	// 네이버 SMS API로 보낼 요청 바디 생성
+	private SmsApiRequest makeSmsApiRequestBody(String phone, String verificationCode) {
+		List<MessageRequest> messages = new ArrayList<>();
+		messages.add(MessageRequest.builder()
+			.to(phone)
+			.content(String.format("[기프티콘 플리마켓] 인증 번호 [%s]를 입력해주세요.", verificationCode))
+			.build());
+
+		return SmsApiRequest.builder()
+			.type("SMS")
+			.contentType("COMM")
+			.countryCode("82")
+			.from(SENDER)
+			.content("기본 메시지")
+			.messages(messages)
+			.build();
+	}
+
+	// 인증 번호 확인
+	public void verifyVerificationCode(SmsVerificationRequest smsRequest) {
+		String findCode = smsCertificationDao.getVerificationCode(smsRequest.getPhone());
+		if (!smsRequest.getVerificationCode().equals(findCode)) {
+			throw new VerificationCodeMisMatchException("인증 번호가 일치하지 않습니다.");
+		}
+		smsCertificationDao.deleteVerificationCode(smsRequest.getPhone());
+	}
+
+	public String makeSignature(String timestamp) {
+		String space = " ";
+		String newLine = "\n";
+		String method = "POST";
+		String url = "/sms/v2/services/" + SERVICE_ID + "/messages";
+
+		String message = new StringBuilder()
+			.append(method)
+			.append(space)
+			.append(url)
+			.append(newLine)
+			.append(timestamp)
+			.append(newLine)
+			.append(ACCESS_KEY)
+			.toString();
+
+		SecretKeySpec signingKey = new SecretKeySpec(SECRET_KEY.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+
+		Mac mac = null;
+		try {
+			mac = Mac.getInstance("HmacSHA256");
+			mac.init(signingKey);
+		} catch (NoSuchAlgorithmException | InvalidKeyException e) {
+			throw new RuntimeException(e);
+		}
+
+		byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+		String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+		return encodeBase64String;
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
@@ -1,26 +1,14 @@
 package com.ghm.giftcardfleamarket.user.service.verification;
 
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ghm.giftcardfleamarket.common.utils.SmsVerificationUtil;
 import com.ghm.giftcardfleamarket.user.dao.SmsVerificationDao;
-import com.ghm.giftcardfleamarket.user.dto.request.MessageRequest;
 import com.ghm.giftcardfleamarket.user.dto.request.SmsApiRequest;
 import com.ghm.giftcardfleamarket.user.dto.request.SmsVerificationRequest;
 import com.ghm.giftcardfleamarket.user.dto.response.SmsApiResponse;
@@ -33,22 +21,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SmsVerificationService {
 
-	private static final String ACCESS_KEY = "iJPkzp82Zq6cU4XgmuQv";
-	private static final String SECRET_KEY = "Rtfhw7caZMJyOksfnRcVTH897dhi7ndAnbx62Oei";
 	private static final String SERVICE_ID = "ncp:sms:kr:306692833450:flea_market";
-	private static final String SENDER = "01024008614";
 	private static final String REQUEST_URL =
 		"https://sens.apigw.ntruss.com/sms/v2/services/" + SERVICE_ID + "/messages";
 
 	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
 	private final SmsVerificationDao smsCertificationDao;
 
 	public void sendSms(String phone) throws JsonProcessingException {
-		HttpHeaders headers = makeSmsApiRequestHeaders();
-		String verificationCode = makeVerificationCode();
-		SmsApiRequest body = makeSmsApiRequestBody(phone, verificationCode);
+		String verificationCode = SmsVerificationUtil.makeVerificationCode();
+		HttpHeaders headers = SmsVerificationUtil.makeSmsApiRequestHeaders();
+		SmsApiRequest body = SmsVerificationUtil.makeSmsApiRequestBody(phone, verificationCode);
 
-		String jsonStrBody = new ObjectMapper().writeValueAsString(body);
+		String jsonStrBody = objectMapper.writeValueAsString(body);
 		HttpEntity<String> httpRequest = new HttpEntity<>(jsonStrBody, headers);
 
 		SmsApiResponse smsApiResponse = restTemplate.postForObject(REQUEST_URL, httpRequest, SmsApiResponse.class);
@@ -58,75 +44,11 @@ public class SmsVerificationService {
 		smsCertificationDao.saveVerificationCode(phone, verificationCode);
 	}
 
-	private HttpHeaders makeSmsApiRequestHeaders() {
-		String timestamp = Long.toString(System.currentTimeMillis());
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_JSON);
-		headers.add("x-ncp-apigw-timestamp", timestamp);
-		headers.add("x-ncp-iam-access-key", ACCESS_KEY);
-		headers.add("x-ncp-apigw-signature-v2", makeSignature(timestamp));
-		return headers;
-	}
-
-	private static String makeVerificationCode() {
-		return String.valueOf(new Random().nextInt(900000) + 100000);
-	}
-
-	private SmsApiRequest makeSmsApiRequestBody(String phone, String verificationCode) {
-		List<MessageRequest> messages = new ArrayList<>();
-		messages.add(MessageRequest.builder()
-			.to(phone)
-			.content(String.format("[기프티콘 플리마켓] 인증 번호 [%s]를 입력해주세요.", verificationCode))
-			.build());
-
-		return SmsApiRequest.builder()
-			.type("SMS")
-			.contentType("COMM")
-			.countryCode("82")
-			.from(SENDER)
-			.content("기본 메시지")
-			.messages(messages)
-			.build();
-	}
-
 	public void verifyVerificationCode(SmsVerificationRequest smsRequest) {
 		String findCode = smsCertificationDao.getVerificationCode(smsRequest.getPhone());
 		if (!smsRequest.getVerificationCode().equals(findCode)) {
 			throw new VerificationCodeMisMatchException("인증 번호가 일치하지 않습니다.");
 		}
 		smsCertificationDao.deleteVerificationCode(smsRequest.getPhone());
-	}
-
-	public String makeSignature(String timestamp) {
-		String space = " ";
-		String newLine = "\n";
-		String method = "POST";
-		String url = "/sms/v2/services/" + SERVICE_ID + "/messages";
-
-		String message = new StringBuilder()
-			.append(method)
-			.append(space)
-			.append(url)
-			.append(newLine)
-			.append(timestamp)
-			.append(newLine)
-			.append(ACCESS_KEY)
-			.toString();
-
-		SecretKeySpec signingKey = new SecretKeySpec(SECRET_KEY.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
-
-		Mac mac = null;
-		try {
-			mac = Mac.getInstance("HmacSHA256");
-			mac.init(signingKey);
-		} catch (NoSuchAlgorithmException | InvalidKeyException e) {
-			throw new RuntimeException(e);
-		}
-
-		byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
-		String encodeBase64String = Base64.encodeBase64String(rawHmac);
-
-		return encodeBase64String;
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/user/service/verification/SmsVerificationService.java
@@ -39,7 +39,7 @@ public class SmsVerificationService {
 
 		SmsApiResponse smsApiResponse = restTemplate.postForObject(REQUEST_URL, httpRequest, SmsApiResponse.class);
 		if (smsApiResponse.getStatusName().equals("fail")) {
-			throw new SmsSendFailedException("SMS 전송에 실패하였습니다.");
+			throw new SmsSendFailedException(smsApiResponse.getStatusCode());
 		}
 		smsCertificationDao.saveVerificationCode(phone, verificationCode);
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   profiles:
     active: dev
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 180000  # 밀리초 단위로 설정
 
 mybatis:
   mapper-locations: classpath:mapper/*.xml


### PR DESCRIPTION
**네이버 클라우드 플랫폼 SMS API**를 사용해서 **휴대폰 SMS 인증**을 구현했습니다.

- Bean Validation
      - 휴대폰 번호 : 하이픈 없이, 010/011로 시작하는 11자리 
      - 인증 번호 : 6자리
- 인증 번호 발송 성공 시, redis에 저장 
      - Key : 휴대폰 번호
      - Value : 인증 번호
- 인증 번호 timeout 3분 설정