### PR TITLE
[#31] 기프티콘 판매 내역 조회 구현

### DIFF
--- a/src/main/java/com/ghm/giftcardfleamarket/brand/service/BrandService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/brand/service/BrandService.java
@@ -36,8 +36,8 @@ public class BrandService {
 	}
 
 	public SaleOptionResponse getBrandNamesByCategory(Long categoryId) {
-		Map<String, Object> categoryIdMap = Map.of("id", categoryId);
-		List<Brand> brandList = brandMapper.selectBrandsByCategory(categoryIdMap);
+		Map<String, Object> idToCategoryId = Map.of("id", categoryId);
+		List<Brand> brandList = brandMapper.selectBrandsByCategory(idToCategoryId);
 
 		if (CollectionUtils.isEmpty(brandList)) {
 			throw new SaleOptionListNotFoundException("브랜드 목록을 찾을 수 없습니다.");

--- a/src/main/java/com/ghm/giftcardfleamarket/brand/service/BrandService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/brand/service/BrandService.java
@@ -27,7 +27,7 @@ public class BrandService {
 	public List<BrandResponse> getBrandsByCategory(Long categoryId, int page) {
 		ArrayList<BrandResponse> brandResponseList = new ArrayList<>();
 
-		Map<String, Object> categoryIdAndPageInfo = putIdAndPageInfoToMap(categoryId, page,
+		Map<String, Object> categoryIdAndPageInfo = makePagingQueryParamsWithMap(categoryId, page,
 			BRAND_PAGE_SIZE.getPageSize());
 		List<Brand> brandList = brandMapper.selectBrandsByCategory(categoryIdAndPageInfo);
 		brandList.forEach(brand -> brandResponseList.add(BrandResponse.of(brand)));

--- a/src/main/java/com/ghm/giftcardfleamarket/common/utils/PaginationUtil.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/utils/PaginationUtil.java
@@ -14,4 +14,12 @@ public class PaginationUtil {
 			Map.entry("pageSize", pageSize),
 			Map.entry("offset", pageable.getOffset()));
 	}
+
+	public static Map<String, Object> putUserIdAndPageInfoToMap(String userId, int page, int pageSize) {
+		Pageable pageable = PageRequest.of(page, pageSize);
+		return Map.ofEntries(
+			Map.entry("userId", userId),
+			Map.entry("pageSize", pageSize),
+			Map.entry("offset", pageable.getOffset()));
+	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/common/utils/PaginationUtil.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/utils/PaginationUtil.java
@@ -7,19 +7,19 @@ import org.springframework.data.domain.Pageable;
 
 public class PaginationUtil {
 
-	public static Map<String, Object> putIdAndPageInfoToMap(Long id, int page, int pageSize) {
+	public static Map<String, Object> makePagingQueryParamsWithMap(Object obj, int page, int pageSize) {
 		Pageable pageable = PageRequest.of(page, pageSize);
 		return Map.ofEntries(
-			Map.entry("id", id),
+			Map.entry(determineMapKeyByType(obj), obj),
 			Map.entry("pageSize", pageSize),
 			Map.entry("offset", pageable.getOffset()));
 	}
 
-	public static Map<String, Object> putUserIdAndPageInfoToMap(String userId, int page, int pageSize) {
-		Pageable pageable = PageRequest.of(page, pageSize);
-		return Map.ofEntries(
-			Map.entry("userId", userId),
-			Map.entry("pageSize", pageSize),
-			Map.entry("offset", pageable.getOffset()));
+	private static String determineMapKeyByType(Object obj) {
+		return switch (obj.getClass().getSimpleName()) {
+			case "Long" -> "id";
+			case "String" -> "userId";
+			default -> "Object";
+		};
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/common/utils/PaginationUtil.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/utils/PaginationUtil.java
@@ -16,10 +16,13 @@ public class PaginationUtil {
 	}
 
 	private static String determineMapKeyByType(Object obj) {
-		return switch (obj.getClass().getSimpleName()) {
-			case "Long" -> "id";
-			case "String" -> "userId";
-			default -> "Object";
-		};
+		if (obj instanceof Long) {
+			return "id";
+		}
+		if (obj instanceof String) {
+			return "userId";
+		}
+
+		throw new IllegalArgumentException("지원하지 않는 타입입니다 : " + obj.getClass().getName());
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/common/utils/constants/Page.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/common/utils/constants/Page.java
@@ -2,7 +2,8 @@ package com.ghm.giftcardfleamarket.common.utils.constants;
 
 public enum Page {
 	BRAND_PAGE_SIZE(9),
-	ITEM_PAGE_SIZE(4);
+	ITEM_PAGE_SIZE(4),
+	SALE_PAGE_SIZE(3);
 
 	private final int pageSize;
 

--- a/src/main/java/com/ghm/giftcardfleamarket/item/mapper/ItemMapper.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/item/mapper/ItemMapper.java
@@ -10,7 +10,7 @@ import com.ghm.giftcardfleamarket.item.domain.Item;
 @Mapper
 public interface ItemMapper {
 
-	List<Item> selectItemsByBrand(Map<String, Object> brandIdAndPageInfo);
+	List<Item> selectItemsByBrand(Map<String, Object> map);
 
 	int selectItemTotalCountByBrand(Long brandId);
 

--- a/src/main/java/com/ghm/giftcardfleamarket/item/service/ItemService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/item/service/ItemService.java
@@ -49,8 +49,8 @@ public class ItemService {
 	}
 
 	public SaleOptionResponse getItemNamesByBrand(Long brandId) {
-		Map<String, Object> brandIdMap = Map.of("id", brandId);
-		List<Item> itemList = itemMapper.selectItemsByBrand(brandIdMap);
+		Map<String, Object> idToBrandId = Map.of("id", brandId);
+		List<Item> itemList = itemMapper.selectItemsByBrand(idToBrandId);
 
 		if (CollectionUtils.isEmpty(itemList)) {
 			throw new SaleOptionListNotFoundException("아이템 목록을 찾을 수 없습니다.");

--- a/src/main/java/com/ghm/giftcardfleamarket/item/service/ItemService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/item/service/ItemService.java
@@ -33,7 +33,8 @@ public class ItemService {
 	public ItemListResponse getItemsByBrand(Long brandId, int page) {
 		List<ItemResponse> itemResponseList = new ArrayList<>();
 
-		Map<String, Object> brandIdAndPageInfo = putIdAndPageInfoToMap(brandId, page, ITEM_PAGE_SIZE.getPageSize());
+		Map<String, Object> brandIdAndPageInfo = makePagingQueryParamsWithMap(brandId, page,
+			ITEM_PAGE_SIZE.getPageSize());
 		List<Item> itemList = itemMapper.selectItemsByBrand(brandIdAndPageInfo);
 		itemList.forEach(item -> itemResponseList.add(ItemResponse.of(item)));
 

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
@@ -10,12 +10,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ghm.giftcardfleamarket.brand.service.BrandService;
 import com.ghm.giftcardfleamarket.category.service.CategoryService;
 import com.ghm.giftcardfleamarket.item.service.ItemService;
 import com.ghm.giftcardfleamarket.sale.dto.request.SaleRequest;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleListResponse;
 import com.ghm.giftcardfleamarket.sale.dto.response.SaleOptionResponse;
 import com.ghm.giftcardfleamarket.sale.service.SaleService;
 
@@ -53,10 +55,15 @@ public class SaleController {
 	}
 
 	@PostMapping("/{itemId}")
-	public ResponseEntity<Void> saleGiftCard(@PathVariable Long itemId,
+	public ResponseEntity<Void> sellGiftCard(@PathVariable Long itemId,
 		@RequestBody @Validated SaleRequest saleRequest) {
 		saleRequest.setItemId(itemId);
-		saleService.saleGiftCard(saleRequest);
+		saleService.sellGiftCard(saleRequest);
 		return new ResponseEntity<>(HttpStatus.CREATED);
+	}
+
+	@GetMapping
+	public ResponseEntity<SaleListResponse> getMySoldGiftCards(@RequestParam(defaultValue = "0") int page) {
+		return new ResponseEntity<>(saleService.getMySoldGiftCards(page), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
@@ -17,8 +17,8 @@ import com.ghm.giftcardfleamarket.brand.service.BrandService;
 import com.ghm.giftcardfleamarket.category.service.CategoryService;
 import com.ghm.giftcardfleamarket.item.service.ItemService;
 import com.ghm.giftcardfleamarket.sale.dto.request.SaleRequest;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleListResponse;
 import com.ghm.giftcardfleamarket.sale.dto.response.SaleOptionResponse;
-import com.ghm.giftcardfleamarket.sale.dto.response.SaleResponse;
 import com.ghm.giftcardfleamarket.sale.service.SaleService;
 
 import lombok.RequiredArgsConstructor;
@@ -63,7 +63,7 @@ public class SaleController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<SaleResponse>> getSaleGiftCards(@RequestParam(defaultValue = "0") int page) {
+	public ResponseEntity<SaleListResponse> getSaleGiftCards(@RequestParam(defaultValue = "0") int page) {
 		return new ResponseEntity<>(saleService.getSaleGiftCards(page), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ghm.giftcardfleamarket.brand.service.BrandService;
@@ -17,6 +18,7 @@ import com.ghm.giftcardfleamarket.category.service.CategoryService;
 import com.ghm.giftcardfleamarket.item.service.ItemService;
 import com.ghm.giftcardfleamarket.sale.dto.request.SaleRequest;
 import com.ghm.giftcardfleamarket.sale.dto.response.SaleOptionResponse;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleResponse;
 import com.ghm.giftcardfleamarket.sale.service.SaleService;
 
 import lombok.RequiredArgsConstructor;
@@ -58,5 +60,10 @@ public class SaleController {
 		saleRequest.setItemId(itemId);
 		saleService.saleGiftCard(saleRequest);
 		return new ResponseEntity<>(HttpStatus.CREATED);
+	}
+
+	@GetMapping
+	public ResponseEntity<List<SaleResponse>> getSaleGiftCards(@RequestParam(defaultValue = "0") int page) {
+		return new ResponseEntity<>(saleService.getSaleGiftCards(page), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/controller/SaleController.java
@@ -55,15 +55,15 @@ public class SaleController {
 	}
 
 	@PostMapping("/{itemId}")
-	public ResponseEntity<Void> saleGiftCard(@PathVariable Long itemId,
+	public ResponseEntity<Void> sellGiftCard(@PathVariable Long itemId,
 		@RequestBody @Validated SaleRequest saleRequest) {
 		saleRequest.setItemId(itemId);
-		saleService.saleGiftCard(saleRequest);
+		saleService.sellGiftCard(saleRequest);
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
 	@GetMapping
-	public ResponseEntity<SaleListResponse> getSaleGiftCards(@RequestParam(defaultValue = "0") int page) {
-		return new ResponseEntity<>(saleService.getSaleGiftCards(page), HttpStatus.OK);
+	public ResponseEntity<SaleListResponse> getMySoldGiftCards(@RequestParam(defaultValue = "0") int page) {
+		return new ResponseEntity<>(saleService.getMySoldGiftCards(page), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/dto/response/SaleListResponse.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/dto/response/SaleListResponse.java
@@ -9,4 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SaleListResponse {
 	private List<SaleResponse> saleResponseList;
+
+	public static SaleListResponse empty() {
+		return null;
+	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/dto/response/SaleListResponse.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/dto/response/SaleListResponse.java
@@ -1,0 +1,12 @@
+package com.ghm.giftcardfleamarket.sale.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SaleListResponse {
+	private List<SaleResponse> saleResponseList;
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/dto/response/SaleResponse.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/dto/response/SaleResponse.java
@@ -1,0 +1,29 @@
+package com.ghm.giftcardfleamarket.sale.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.ghm.giftcardfleamarket.sale.domain.Sale;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SaleResponse {
+	private String itemName;
+	private int salePrice;
+	private String barcodeLast6Digit;
+	private LocalDate expirationDate;
+	private LocalDateTime registeredAt;
+
+	public static SaleResponse of(Sale sale, String itemName, int salePrice) {
+		return SaleResponse.builder()
+			.itemName(itemName)
+			.salePrice(salePrice)
+			.barcodeLast6Digit(sale.getBarcode().substring(6))
+			.expirationDate(sale.getExpirationDate())
+			.registeredAt(sale.getRegisteredAt())
+			.build();
+	}
+}

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/mapper/SaleMapper.java
@@ -1,5 +1,8 @@
 package com.ghm.giftcardfleamarket.sale.mapper;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.ibatis.annotations.Mapper;
 
 import com.ghm.giftcardfleamarket.sale.domain.Sale;
@@ -10,4 +13,6 @@ public interface SaleMapper {
 	void insertSaleGiftCard(Sale sale);
 
 	boolean hasBarcode(String barcode);
+
+	List<Sale> selectMySoldGiftCards(Map<String, Object> userIdAndPageInfo);
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/mapper/SaleMapper.java
@@ -10,9 +10,9 @@ import com.ghm.giftcardfleamarket.sale.domain.Sale;
 @Mapper
 public interface SaleMapper {
 
-	void insertSaleGiftCard(Sale sale);
+	void insertGiftCard(Sale sale);
 
 	boolean hasBarcode(String barcode);
 
-	List<Sale> selectSaleGiftCard(Map<String, Object> userIdAndPageInfo);
+	List<Sale> selectMySoldGiftCards(Map<String, Object> userIdAndPageInfo);
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/mapper/SaleMapper.java
@@ -1,5 +1,8 @@
 package com.ghm.giftcardfleamarket.sale.mapper;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.ibatis.annotations.Mapper;
 
 import com.ghm.giftcardfleamarket.sale.domain.Sale;
@@ -10,4 +13,6 @@ public interface SaleMapper {
 	void insertSaleGiftCard(Sale sale);
 
 	boolean hasBarcode(String barcode);
+
+	List<Sale> selectSaleGiftCard(Map<String, Object> userIdAndPageInfo);
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -42,7 +42,7 @@ public class SaleService {
 	}
 
 	public SaleListResponse getMySoldGiftCards(int page) {
-		Map<String, Object> userIdAndPageInfo = putUserIdAndPageInfoToMap(findLoginUserIdInSession(), page,
+		Map<String, Object> userIdAndPageInfo = makePagingQueryParamsWithMap(findLoginUserIdInSession(), page,
 			SALE_PAGE_SIZE.getPageSize());
 		List<Sale> saleList = saleMapper.selectMySoldGiftCards(userIdAndPageInfo);
 

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -20,6 +20,7 @@ import com.ghm.giftcardfleamarket.sale.dto.response.SaleListResponse;
 import com.ghm.giftcardfleamarket.sale.dto.response.SaleResponse;
 import com.ghm.giftcardfleamarket.sale.exception.DuplicatedBarcodeException;
 import com.ghm.giftcardfleamarket.sale.mapper.SaleMapper;
+import com.ghm.giftcardfleamarket.user.exception.UnauthorizedUserException;
 import com.ghm.giftcardfleamarket.user.mapper.UserMapper;
 import com.ghm.giftcardfleamarket.user.service.LoginService;
 
@@ -59,6 +60,8 @@ public class SaleService {
 
 	private String findLoginUserIdInSession() {
 		Optional<Long> loginUser = loginService.getLoginUser();
+		loginUser.orElseThrow(() -> new UnauthorizedUserException("로그인 후 이용 가능합니다."));
+
 		return userMapper.selectUserIdById(loginUser.get());
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -48,7 +48,7 @@ public class SaleService {
 		List<Sale> saleList = saleMapper.selectMySoldGiftCards(userIdAndPageInfo);
 
 		if (CollectionUtils.isEmpty(saleList)) {
-			return null;
+			return SaleListResponse.empty();
 		}
 
 		List<SaleResponse> saleResponseList = saleList.stream()

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -34,20 +34,20 @@ public class SaleService {
 	private final ItemMapper itemMapper;
 	private final LoginService loginService;
 
-	public void saleGiftCard(SaleRequest saleRequest) {
+	public void sellGiftCard(SaleRequest saleRequest) {
 		if (saleMapper.hasBarcode(saleRequest.getBarcode())) {
 			throw new DuplicatedBarcodeException("이미 등록된 바코드입니다.");
 		}
-		saleMapper.insertSaleGiftCard(saleRequest.toEntity(findLoginUserIdInSession()));
+		saleMapper.insertGiftCard(saleRequest.toEntity(findLoginUserIdInSession()));
 	}
 
-	public SaleListResponse getSaleGiftCards(int page) {
+	public SaleListResponse getMySoldGiftCards(int page) {
 		List<SaleResponse> saleResponseList = new ArrayList<>();
 
 		Map<String, Object> userIdAndPageInfo = putUserIdAndPageInfoToMap(findLoginUserIdInSession(), page,
 			SALE_PAGE_SIZE.getPageSize());
 
-		List<Sale> saleList = saleMapper.selectSaleGiftCard(userIdAndPageInfo);
+		List<Sale> saleList = saleMapper.selectMySoldGiftCards(userIdAndPageInfo);
 		saleList.forEach(sale -> {
 			Item item = itemMapper.selectItemDetails(sale.getItemId());
 			saleResponseList.add(

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -7,7 +7,6 @@ import static com.ghm.giftcardfleamarket.common.utils.constants.PriceRate.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -62,9 +61,8 @@ public class SaleService {
 	}
 
 	private String findLoginUserIdInSession() {
-		Optional<Long> loginUser = loginService.getLoginUser();
-		loginUser.orElseThrow(() -> new UnauthorizedUserException("로그인 후 이용 가능합니다."));
-
-		return userMapper.selectUserIdById(loginUser.get());
+		return loginService.getLoginUser()
+			.map(userMapper::selectUserIdById)
+			.orElseThrow(() -> new UnauthorizedUserException("로그인 후 이용 가능합니다."));
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -1,10 +1,22 @@
 package com.ghm.giftcardfleamarket.sale.service;
 
+import static com.ghm.giftcardfleamarket.common.utils.PaginationUtil.*;
+import static com.ghm.giftcardfleamarket.common.utils.PriceCalculationUtil.*;
+import static com.ghm.giftcardfleamarket.common.utils.constants.Page.*;
+import static com.ghm.giftcardfleamarket.common.utils.constants.PriceRate.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.ghm.giftcardfleamarket.item.domain.Item;
+import com.ghm.giftcardfleamarket.item.mapper.ItemMapper;
+import com.ghm.giftcardfleamarket.sale.domain.Sale;
 import com.ghm.giftcardfleamarket.sale.dto.request.SaleRequest;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleResponse;
 import com.ghm.giftcardfleamarket.sale.exception.DuplicatedBarcodeException;
 import com.ghm.giftcardfleamarket.sale.mapper.SaleMapper;
 import com.ghm.giftcardfleamarket.user.mapper.UserMapper;
@@ -18,16 +30,34 @@ public class SaleService {
 
 	private final SaleMapper saleMapper;
 	private final UserMapper userMapper;
+	private final ItemMapper itemMapper;
 	private final LoginService loginService;
 
 	public void saleGiftCard(SaleRequest saleRequest) {
 		if (saleMapper.hasBarcode(saleRequest.getBarcode())) {
 			throw new DuplicatedBarcodeException("이미 등록된 바코드입니다.");
 		}
+		saleMapper.insertSaleGiftCard(saleRequest.toEntity(findLoginUserIdInSession()));
+	}
 
+	public List<SaleResponse> getSaleGiftCards(int page) {
+		List<SaleResponse> saleResponseList = new ArrayList<>();
+
+		Map<String, Object> userIdAndPageInfo = putUserIdAndPageInfoToMap(findLoginUserIdInSession(), page,
+			SALE_PAGE_SIZE.getPageSize());
+
+		List<Sale> saleList = saleMapper.selectSaleGiftCard(userIdAndPageInfo);
+		saleList.forEach(sale -> {
+			Item item = itemMapper.selectItemDetails(sale.getItemId());
+			saleResponseList.add(
+				SaleResponse.of(sale, item.getName(), calculatePrice(item.getPrice(), PROPOSAL_RATE.getRate())));
+		});
+
+		return saleResponseList;
+	}
+
+	private String findLoginUserIdInSession() {
 		Optional<Long> loginUser = loginService.getLoginUser();
-		String loginUserId = userMapper.selectUserIdById(loginUser.get());
-
-		saleMapper.insertSaleGiftCard(saleRequest.toEntity(loginUserId));
+		return userMapper.selectUserIdById(loginUser.get());
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -1,10 +1,23 @@
 package com.ghm.giftcardfleamarket.sale.service;
 
+import static com.ghm.giftcardfleamarket.common.utils.PaginationUtil.*;
+import static com.ghm.giftcardfleamarket.common.utils.PriceCalculationUtil.*;
+import static com.ghm.giftcardfleamarket.common.utils.constants.Page.*;
+import static com.ghm.giftcardfleamarket.common.utils.constants.PriceRate.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.ghm.giftcardfleamarket.item.domain.Item;
+import com.ghm.giftcardfleamarket.item.mapper.ItemMapper;
+import com.ghm.giftcardfleamarket.sale.domain.Sale;
 import com.ghm.giftcardfleamarket.sale.dto.request.SaleRequest;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleListResponse;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleResponse;
 import com.ghm.giftcardfleamarket.sale.exception.DuplicatedBarcodeException;
 import com.ghm.giftcardfleamarket.sale.mapper.SaleMapper;
 import com.ghm.giftcardfleamarket.user.exception.UnauthorizedUserException;
@@ -19,17 +32,36 @@ public class SaleService {
 
 	private final SaleMapper saleMapper;
 	private final UserMapper userMapper;
+	private final ItemMapper itemMapper;
 	private final LoginService loginService;
 
-	public void saleGiftCard(SaleRequest saleRequest) {
+	public void sellGiftCard(SaleRequest saleRequest) {
 		if (saleMapper.hasBarcode(saleRequest.getBarcode())) {
 			throw new DuplicatedBarcodeException("이미 등록된 바코드입니다.");
 		}
+		saleMapper.insertSaleGiftCard(saleRequest.toEntity(findLoginUserIdInSession()));
+	}
 
+	public SaleListResponse getMySoldGiftCards(int page) {
+		List<SaleResponse> saleResponseList = new ArrayList<>();
+
+		Map<String, Object> userIdAndPageInfo = putUserIdAndPageInfoToMap(findLoginUserIdInSession(), page,
+			SALE_PAGE_SIZE.getPageSize());
+
+		List<Sale> saleList = saleMapper.selectMySoldGiftCards(userIdAndPageInfo);
+		saleList.forEach(sale -> {
+			Item item = itemMapper.selectItemDetails(sale.getItemId());
+			saleResponseList.add(
+				SaleResponse.of(sale, item.getName(), calculatePrice(item.getPrice(), PROPOSAL_RATE.getRate())));
+		});
+
+		return new SaleListResponse(saleResponseList);
+	}
+
+	private String findLoginUserIdInSession() {
 		Optional<Long> loginUser = loginService.getLoginUser();
 		loginUser.orElseThrow(() -> new UnauthorizedUserException("로그인 후 이용 가능합니다."));
 
-		String loginUserId = userMapper.selectUserIdById(loginUser.get());
-		saleMapper.insertSaleGiftCard(saleRequest.toEntity(loginUserId));
+		return userMapper.selectUserIdById(loginUser.get());
 	}
 }

--- a/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
+++ b/src/main/java/com/ghm/giftcardfleamarket/sale/service/SaleService.java
@@ -16,6 +16,7 @@ import com.ghm.giftcardfleamarket.item.domain.Item;
 import com.ghm.giftcardfleamarket.item.mapper.ItemMapper;
 import com.ghm.giftcardfleamarket.sale.domain.Sale;
 import com.ghm.giftcardfleamarket.sale.dto.request.SaleRequest;
+import com.ghm.giftcardfleamarket.sale.dto.response.SaleListResponse;
 import com.ghm.giftcardfleamarket.sale.dto.response.SaleResponse;
 import com.ghm.giftcardfleamarket.sale.exception.DuplicatedBarcodeException;
 import com.ghm.giftcardfleamarket.sale.mapper.SaleMapper;
@@ -40,7 +41,7 @@ public class SaleService {
 		saleMapper.insertSaleGiftCard(saleRequest.toEntity(findLoginUserIdInSession()));
 	}
 
-	public List<SaleResponse> getSaleGiftCards(int page) {
+	public SaleListResponse getSaleGiftCards(int page) {
 		List<SaleResponse> saleResponseList = new ArrayList<>();
 
 		Map<String, Object> userIdAndPageInfo = putUserIdAndPageInfoToMap(findLoginUserIdInSession(), page,
@@ -53,7 +54,7 @@ public class SaleService {
 				SaleResponse.of(sale, item.getName(), calculatePrice(item.getPrice(), PROPOSAL_RATE.getRate())));
 		});
 
-		return saleResponseList;
+		return new SaleListResponse(saleResponseList);
 	}
 
 	private String findLoginUserIdInSession() {

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -4,6 +4,12 @@
 
 <mapper namespace="com.ghm.giftcardfleamarket.sale.mapper.SaleMapper">
 
+    <resultMap id="saleResultMap" type="Sale">
+        <result property="itemId" column="item_id"/>
+        <result property="expirationDate" column="expiration_date"/>
+        <result property="registeredAt" column="registered_at"/>
+    </resultMap>
+
     <insert id="insertSaleGiftCard" parameterType="Sale">
         INSERT INTO sale(seller_id, item_id, barcode, expiration_date, registered_at)
         VALUES (#{sellerId}, #{itemId}, #{barcode}, #{expirationDate}, #{registeredAt})
@@ -12,6 +18,12 @@
     <select id="hasBarcode" parameterType="String" resultType="boolean">
         SELECT EXISTS
         (SELECT barcode FROM sale WHERE barcode = #{barcode})
+    </select>
+
+    <select id="selectSaleGiftCard" parameterType="map" resultMap="saleResultMap">
+        SELECT item_id, barcode, expiration_date, registered_at FROM sale
+        WHERE seller_id = #{userId}
+        LIMIT #{pageSize} OFFSET #{offset}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -10,7 +10,7 @@
         <result property="registeredAt" column="registered_at"/>
     </resultMap>
 
-    <insert id="insertSaleGiftCard" parameterType="Sale">
+    <insert id="insertGiftCard" parameterType="Sale">
         INSERT INTO sale(seller_id, item_id, barcode, expiration_date, registered_at)
         VALUES (#{sellerId}, #{itemId}, #{barcode}, #{expirationDate}, #{registeredAt})
     </insert>
@@ -20,7 +20,7 @@
         (SELECT barcode FROM sale WHERE barcode = #{barcode})
     </select>
 
-    <select id="selectSaleGiftCard" parameterType="map" resultMap="saleResultMap">
+    <select id="selectMySoldGiftCards" parameterType="map" resultMap="saleResultMap">
         SELECT item_id, barcode, expiration_date, registered_at FROM sale
         WHERE seller_id = #{userId}
         LIMIT #{pageSize} OFFSET #{offset}

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -4,6 +4,12 @@
 
 <mapper namespace="com.ghm.giftcardfleamarket.sale.mapper.SaleMapper">
 
+    <resultMap id="saleResultMap" type="Sale">
+        <result property="itemId" column="item_id"/>
+        <result property="expirationDate" column="expiration_date"/>
+        <result property="registeredAt" column="registered_at"/>
+    </resultMap>
+
     <insert id="insertSaleGiftCard" parameterType="Sale">
         INSERT INTO sale(seller_id, item_id, barcode, expiration_date, registered_at)
         VALUES (#{sellerId}, #{itemId}, #{barcode}, #{expirationDate}, #{registeredAt})
@@ -12,6 +18,12 @@
     <select id="hasBarcode" parameterType="String" resultType="boolean">
         SELECT EXISTS
         (SELECT barcode FROM sale WHERE barcode = #{barcode})
+    </select>
+
+    <select id="selectMySoldGiftCards" parameterType="map" resultMap="saleResultMap">
+        SELECT item_id, barcode, expiration_date, registered_at FROM sale
+        WHERE seller_id = #{userId}
+        LIMIT #{pageSize} OFFSET #{offset}
     </select>
 
 </mapper>


### PR DESCRIPTION
- 기프티콘 판매 내역 조회 구현
      - 페이징 처리 : 페이지 당 3개의 목록 출력
      - DTO(SaleResponse) : 상품명, 판매한가격, 바코드뒤6자리, 유효기간, 판매일자